### PR TITLE
Use PyGame for audio

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -65,12 +65,17 @@ are attributed in the distributions of the below mentioned primary dependencies.
 ### Python Jinja2
 * Copyright 2009-2017 Jinja Team
 * License: <https://raw.githubusercontent.com/pallets/jinja/master/LICENSE>
-* URI: <http://jinja.pocoo.org/>
+* URI: <https://jinja.palletsprojects.com/>
+
+### Python PyGame
+* Copyright 2000-2022 PyGame Team
+* License: <https://raw.githubusercontent.com/pygame/pygame/main/docs/LGPL.txt>
+* URI: <https://www.pygame.org/>
 
 ## Sound Effects
 
 ### Blip_Select.oga
-* Copyrignt 2014 Damaged Panda
+* Copyright 2014 Damaged Panda
 * License: <http://creativecommons.org/licenses/by/3.0/>
 * Title: 100 plus game sound effects
 * URI: <http://opengameart.org/content/100-plus-game-sound-effects-wavoggm4a>

--- a/README.md
+++ b/README.md
@@ -35,11 +35,12 @@ Current features include:
 * SDL2_image
 * SDL2_mixer
 * SDL2_ttf
-* Python >= 3.5.0
+* Python >= 3.6.0
 * Python jsonschema <https://pypi.python.org/pypi/jsonschema>
 * Python PySDL2 <https://pypi.python.org/pypi/PySDL2/>
 * Python ubjson <https://pypi.python.org/pypi/py-ubjson>
-* Python Jinja2 <http://jinja.pocoo.org/>
+* Python Jinja2 <https://jinja.palletsprojects.com/>
+* Python PyGame <https://www.pygame.org/>
 
 
 ## Running

--- a/config.json
+++ b/config.json
@@ -19,9 +19,7 @@
     "debug": true
   },
   "audio": {
-    "support": ["ogg"],
     "frequency": 22050,
-    "chunksize": 4096,
     "music_volume": 128,
     "sfx_volume": 128
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jinja2
 jsonschema
 PySDL2
 py-ubjson
+pygame

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -30,7 +30,7 @@ import signal
 import sys
 
 VCUR = sys.version_info
-VREQ = [3, 5, 0]
+VREQ = [3, 6, 0]
 
 # We have to do this here before we start pulling in nonexistent imports.
 if __name__ == "__main__":
@@ -55,6 +55,24 @@ if __name__ == "__main__":
         print("Please make sure that SDL2, SDL2_image, SDL2_mixer, and SDL2_TTF are installed.")
         print("Also make sure that the \"pysdl2\" Python3 package is installed.")
         print("On most systems, run \"pip3 install pysdl2\". If pip3 is missing, try pip instead.")
+        sys.exit(1)  # Fail.
+
+    # Try to import pygame.
+    try:
+        os.environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "true"
+        import pygame
+    except ImportError:
+        print("Driftwood 2D\n[0] Starting up...")
+        print("[0] FATAL: __main__: pygame required, module \"pygame\" not found")
+        print("Please make sure that the \"pygame\" Python3 module is installed.")
+        print("On most systems, run \"pip3 install pygame\". If pip3 is missing, try pip instead.")
+        sys.exit(1)  # Fail.
+    try:
+        import pygame.mixer
+    except ImportError:
+        print("Driftwood 2D\n[0] Starting up...")
+        print("[0] FATAL: __main__: pygame required, module \"pygame.mixer\" not found")
+        # TODO: Provide suggestion for the user.
         sys.exit(1)  # Fail.
 
     # Try to import jsonschema.

--- a/src/__schema__.py
+++ b/src/__schema__.py
@@ -84,22 +84,7 @@ _S_CONFIG = """
     "audio": {
       "type": "object",
       "properties": {
-        "support": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "ogg",
-              "mp3",
-              "flac"
-            ]
-          }
-        },
         "frequency": {
-          "type": "integer",
-          "minimum": 1
-        },
-        "chunksize": {
           "type": "integer",
           "minimum": 1
         },
@@ -115,9 +100,7 @@ _S_CONFIG = """
         }
       },
       "required": [
-        "support",
         "frequency",
-        "chunksize",
         "music_volume",
         "sfx_volume"
       ]


### PR DESCRIPTION
### Summary

This PR replaces PySDL with PyGame for our audio playback. PySDL is still used for window and graphics functions.

### Details

* A lot of the functions in `audiomanager.py` have simpler implementations. Some are now even one-liners!
* Volume in PyGame goes from 0.0 to 1.0 instead of 0 to 128 for PySDL.
* `BytesStream` is a hack for the PyGame API since they want a `File` but we only have a `bytes`.
* I've replaced the usual SDL streaming "music" with a non-streaming "sound" object.
  * Channel 0 is reserved for music while channels 1 through 7 are for sound effects.
  * This probably slows our boot process since we decode the entire music file at once.
  * This was part of an exploration that I no longer believe is necessary. We can probably move back to streaming if we want.
* All audio formats are always supported. There is no ability to opt out of FLAC support, for instance.
  * Removed `audio.support` value in `config.json`.
* Lost `volume_sfx_by_filename` and `stop_sfx_by_filename`. (They were not in use yet.)